### PR TITLE
fix: restructure workspace dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ This is a UV workspace containing multiple AI framework projects. Each project h
 ```
 ai-lab/
 ├── pyproject.toml              # Workspace configuration
+├── uv.lock                     # Shared lockfile
 ├── .venv/                      # Shared virtual environment
 └── langchain_lab/              # LangChain project
-    └── pyproject.toml          # LangChain dependencies
+    └── pyproject.toml          # Project-specific dependencies
 ```
 
 ## Projects
@@ -36,10 +37,10 @@ Each project has complete setup instructions in its README:
 
 ## Workspace Reference
 
-Common commands for working with the UV workspace:
+Common commands for working with the UV workspace from the **root directory**:
 
 ```bash
-# Install specific project
+# Install specific project dependencies
 uv sync --package PROJECT_NAME
 
 # Add dependency to specific project  

--- a/langchain_lab/README.md
+++ b/langchain_lab/README.md
@@ -18,14 +18,14 @@ LangChain Lab is part of the AI Lab workspace for exploring and mastering LangCh
 ### Installation
 
 ```bash
-# 1. Clone Repository
+# 1. Clone repository
 git clone https://github.com/tmoesl/ai-lab
 cd ai-lab
 
-# 2. Install Dependencies
-uv sync --package langchain-lab
+# 2. Install dependencies (--no-dev skips dev packages)
+uv sync --package langchain-lab --no-dev 
 
-# 3. Create Environment File
+# 3. Create environment file
 cp .env.example .env
 ```
 

--- a/langchain_lab/pyproject.toml
+++ b/langchain_lab/pyproject.toml
@@ -14,10 +14,13 @@ dependencies = [
     "langgraph>=0.6.6",
     "openai>=1.100.1",
     "pypdf>=6.0.0",
+    "python-dotenv>=1.1.1",
 ]
 
 [dependency-groups]
-dev = []
+dev = [
+    "ipykernel>=6.30.1",
+]
 
 [tool.uv]
 package = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,6 @@ package = false
 [tool.uv.workspace]
 members = ["langchain_lab"] # directories
 
-[dependency-groups]
-dev = [
-    "ipykernel>=6.30.1",
-    "python-dotenv>=1.1.1",
-]
-
 [tool.ruff]
 exclude = [
   ".git",

--- a/uv.lock
+++ b/uv.lock
@@ -18,20 +18,6 @@ name = "ai-lab"
 version = "0.1.0"
 source = { virtual = "." }
 
-[package.dev-dependencies]
-dev = [
-    { name = "ipykernel" },
-    { name = "python-dotenv" },
-]
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "ipykernel", specifier = ">=6.30.1" },
-    { name = "python-dotenv", specifier = ">=1.1.1" },
-]
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -1002,6 +988,12 @@ dependencies = [
     { name = "langgraph" },
     { name = "openai" },
     { name = "pypdf" },
+    { name = "python-dotenv" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "ipykernel" },
 ]
 
 [package.metadata]
@@ -1015,10 +1007,11 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.6.6" },
     { name = "openai", specifier = ">=1.100.1" },
     { name = "pypdf", specifier = ">=6.0.0" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "ipykernel", specifier = ">=6.30.1" }]
 
 [[package]]
 name = "langchain-openai"


### PR DESCRIPTION
- Move python-dotenv and ipykernel to langchain-lab project
- Update installation instructions for workspace structure
- Add uv.lock to project structure documentation